### PR TITLE
story/DEV-1934 Add cleanup handlers for ExactJS

### DIFF
--- a/pay-from-browser/components/Cart.tsx
+++ b/pay-from-browser/components/Cart.tsx
@@ -14,7 +14,7 @@ const Cart: FC<{}> = () => {
   return (
     <>
       {store.items.map(item => {
-        return <CartItem itemnum={item.itemnum} price={0} />
+        return <CartItem key={item.itemnum} itemnum={item.itemnum} price={0} />
       })}
     </>
   )

--- a/pay-from-browser/components/CheckoutButton.tsx
+++ b/pay-from-browser/components/CheckoutButton.tsx
@@ -1,22 +1,73 @@
-import { useCartState } from '../util/useCartState'
+import { useRouter } from "next/router";
 import Link from 'next/link'
+import { useCartState } from '../util/useCartState'
 import styles from '../styles/Home.module.css'
 import { useState } from 'react'
 import Switch from 'react-switch'
+import axios from 'axios'
+import { totalPrice } from './OrderTotal'
+import { Order } from "../types";
 
-const CheckoutButton  = () => {
-    const store = useCartState()
-    const isEmpty = store.items.length == 0
+const CheckoutButton = () => {
+  const router = useRouter();
+  const store = useCartState()
+  const isEmpty = store.items.length == 0
   const [altCheckoutSelected, setAltCheckoutSelected] = useState(false);
 
-    return (
-      isEmpty ? <></> : <>
-      <div className={styles.switch}>
-          <Switch checked={altCheckoutSelected} onChange={setAltCheckoutSelected} onColor='#7ac833' offColor= '#000000' activeBoxShadow='7ac833' uncheckedIcon={false} checkedIcon={false}/>
-          <p className={altCheckoutSelected ? styles.switchlabelgreen :'' }>Alternate Checkout UI</p>
-      </div>
-      <Link href= {altCheckoutSelected ? 'checkout2' : 'checkout'} className={styles.card}>Checkout</Link>
-      </>
-    )
+  const createOrUpdateOrder = (event: any) => {
+    event.preventDefault();
+    const order = store.order
+    if (order == null) {
+      createOrder(event.target.href);
+    } else {
+      updateOrder(order, event.target.href);
+    }
   }
+
+  const createOrder = (nextLocation: string) => {
+    const url = process.env.NEXT_PUBLIC_BASE_URL + '/api/createOrder'
+
+    const amount = totalPrice(store.items); //Price is in cents
+    axios.post(url, {
+      amount: amount
+    }).then((response) => {
+      console.debug("Order created")
+      store.setOrder({
+        token: response.data.token,
+        orderId: response.data.orderId,
+        totalAmount: amount
+      })
+      router.push(nextLocation)
+    })
+  }
+
+  const updateOrder = (order: Order, nextLocation: string) => {
+    const url = process.env.NEXT_PUBLIC_BASE_URL + '/api/updateOrder'
+
+    const amount = totalPrice(store.items); //Price is in cents
+    if (amount !== order.totalAmount) {
+      axios.post(url, {
+        orderId: store.order?.orderId,
+        amount: amount
+      }).then((response) => {
+        console.debug("Order updated")
+        order.totalAmount = response.data.amount
+        store.setOrder(order)
+        router.push(nextLocation)
+      })
+    } else {
+      router.push(nextLocation)
+    }
+  }
+
+  return (
+    isEmpty ? <></> : <>
+      <div className={styles.switch}>
+        <Switch checked={altCheckoutSelected} onChange={setAltCheckoutSelected} onColor='#7ac833' offColor='#000000' activeBoxShadow='7ac833' uncheckedIcon={false} checkedIcon={false} />
+        <p className={altCheckoutSelected ? styles.switchlabelgreen : ''}>Alternate Checkout UI</p>
+      </div>
+      <Link href={altCheckoutSelected ? 'checkout2' : 'checkout'} className={styles.card} onClick={createOrUpdateOrder}>Checkout</Link>
+    </>
+  )
+}
 export default CheckoutButton  

--- a/pay-from-browser/components/Disclaimer.tsx
+++ b/pay-from-browser/components/Disclaimer.tsx
@@ -1,0 +1,13 @@
+import styles from '../styles/Home.module.css'
+
+const Disclaimer = () => {
+  return (
+    <div className={styles.checkoutdisclaimer}>
+      <h1>Demonstration only.</h1>
+      <h2>Payments are simulated and no actual funds are transferred.</h2>
+      <h2><a href="https://developer.exactpay.com/docs/Sandbox-Test-Cards" target="_blank">TEST CARDS</a></h2>
+    </div>
+  )
+};
+
+export default Disclaimer

--- a/pay-from-browser/pages/api/createOrder.ts
+++ b/pay-from-browser/pages/api/createOrder.ts
@@ -2,11 +2,11 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import axios from 'axios'
 import { AxiosRequestConfig } from 'axios'
 
-import { Data } from '../../types'
+import { Order } from '../../types'
 
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Data>
+  res: NextApiResponse
 ) {
   const options: AxiosRequestConfig = {
     method: 'POST',
@@ -17,7 +17,7 @@ export default async function handler(
       authorization: process.env.APPLICATION_TOKEN
     },
     data: {
-      ...req.body,
+      amount: req.body.amount,
       reference: { referenceNo: "sample for demo" }
     }
   };

--- a/pay-from-browser/pages/api/createOrder.ts
+++ b/pay-from-browser/pages/api/createOrder.ts
@@ -2,8 +2,6 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import axios from 'axios'
 import { AxiosRequestConfig } from 'axios'
 
-import { Order } from '../../types'
-
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse

--- a/pay-from-browser/pages/api/postOrders.ts
+++ b/pay-from-browser/pages/api/postOrders.ts
@@ -29,7 +29,6 @@ export default async function handler(
         token: response.data.accessToken.token,
         orderId: response.data.id
       })
-
     })
     .catch((error) => {
       console.error(error);

--- a/pay-from-browser/pages/api/updateOrder.ts
+++ b/pay-from-browser/pages/api/updateOrder.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import axios from 'axios'
+import { AxiosRequestConfig } from 'axios'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const options: AxiosRequestConfig = {
+    method: 'PUT',
+    url: `https://${process.env.NEXT_PUBLIC_P2_DOMAIN}/account/${process.env.P2_ACCOUNT_ID}/orders/${req.body.orderId}`,
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      authorization: process.env.APPLICATION_TOKEN
+    },
+    data: {
+      amount: req.body.amount,
+    }
+  };
+  await axios
+    .request(options)
+    .then(() => {
+      res.status(200)
+      res.json({
+        amount: req.body.amount
+      })
+    })
+    .catch((error) => {
+      console.error(error);
+      res.status(401)
+      res.end()
+    });
+}

--- a/pay-from-browser/pages/checkout.tsx
+++ b/pay-from-browser/pages/checkout.tsx
@@ -23,7 +23,7 @@ export default function Checkout() {
   const onExactJSReady = useCallback(() => {
     setIsLoading(false)
 
-    axios.post(`${process.env.NEXT_PUBLIC_BASE_URL}/api/postOrders`, { 
+    axios.post(`${process.env.NEXT_PUBLIC_BASE_URL}/api/postOrders`, {
       amount: totalPrice(items), //Price is in cents
     }).then((response) => {
       const newExact = ExactJS(response.data.token)
@@ -39,17 +39,17 @@ export default function Checkout() {
           },
         },
         wallets: true
-      })
+      });
 
       newExact.on("payment-complete", (payload: unknown) => {
         const paymentPayload = payload as ExactJSPaymentPayload
-
+        console.debug(`MERCHANT payment complete: ${JSON.stringify(payload)}`);
         (document.getElementById('payment_id')! as HTMLInputElement).value = paymentPayload.paymentId;
         (document.getElementById('myForm') as HTMLFormElement).submit();
       })
 
       newExact.on("payment-failed", (payload) => {
-        console.debug(payload);
+        console.debug(`MERCHANT payment failed: ${JSON.stringify(payload)}`);
       })
 
       setExact(newExact)
@@ -92,37 +92,37 @@ export default function Checkout() {
                 <label htmlFor="email">Email Address</label>
                 <input type="email" id="email" name="email" autoComplete="email" />
               </div>
-  
+
               <div id="cardElement" className={styles.paymentElement}>
               </div>
-  
+
               <div>
                 <label htmlFor="address">Address</label>
                 <input type="text" id="address" name="address" autoComplete="street-address" />
               </div>
-  
+
               <div>
                 <label htmlFor="apartment">Apartment, suite, etc.</label>
                 <input type="text" id="apartment" name="apartment" />
               </div>
-  
+
               <div>
                 <label htmlFor="city">City</label>
                 <input type="text" id="city" name="city" />
               </div>
-  
+
               <div>
                 <label htmlFor="province">State</label>
                 <input type="text" id="province" name="province" />
               </div>
-  
+
               <div>
                 <label htmlFor="postcode">Postal code</label>
                 <input type="text" id="postcode" name="postcode" autoComplete="postal-code" />
               </div>
-  
+
               <input type="hidden" name="payment_id" id="payment_id"></input>
-  
+
               <div>
                 <input type="submit" name="commit" value="Pay Now" data-disable-with="Pay Now" />
               </div>

--- a/pay-from-browser/pages/checkout2.tsx
+++ b/pay-from-browser/pages/checkout2.tsx
@@ -1,26 +1,23 @@
-import axios from 'axios'
-import { FormEvent, useEffect, useCallback, useState } from "react"
-import { MutatingDots } from "react-loader-spinner"
-
+import { FormEvent, useCallback, useEffect } from "react"
 import { useRouter } from "next/router"
 
 import { useCartState } from "../util/useCartState"
-import { totalPrice, OrderTotal } from "../components/OrderTotal"
+import { OrderTotal } from "../components/OrderTotal"
+import Disclaimer from "../components/Disclaimer"
 
 import styles from '../styles/Home.module.css'
 
 import { Exact, ExactJSPaymentPayload, ExactPaymentForm } from '../types'
 
 export default function Checkout() {
-  const [exact, setExact] = useState<Exact | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
+  let exact: Exact | null = null
 
   const router = useRouter()
   const store = useCartState()
 
-  const onExactJSReady = useCallback(() => {
-    const newExact = ExactJS(store.order?.token as string)
-    const components = newExact.components({ orderId: store.order?.orderId as string })
+  const configureExactJS = () => {
+    exact = ExactJS(store.order?.token as string)
+    const components = exact.components({ orderId: store.order?.orderId as string })
 
     components.addComponent('cardDiv', 'card-number', {
       label: { position: "inside" },
@@ -53,44 +50,61 @@ export default function Checkout() {
       }
     });
 
-    newExact.on("payment-complete", (payload: unknown) => {
+    components.addComponent('addressDiv', 'address', {
+      billingAddress: {
+        type: 'minimal',
+      },
+      label: { position: "above" },
+      style: {
+        default: {
+          padding: '2px',
+          border: "1px solid #ccc",
+          fontSize: "14px",
+        },
+      }
+    });
+
+    exact.on("payment-complete", (payload: unknown) => {
       const paymentPayload = payload as ExactJSPaymentPayload
       console.debug(`MERCHANT payment complete: ${JSON.stringify(payload)}`);
       (document.getElementById('payment_id')! as HTMLInputElement).value = paymentPayload.paymentId;
       (document.getElementById('myForm') as HTMLFormElement).submit();
     });
 
-    newExact.on("payment-failed", (payload) => {
+    exact.on("payment-failed", (payload) => {
       console.debug(`MERCHANT payment failed: ${JSON.stringify(payload)}`);
     });
-
-    setExact(newExact);
-  }, [])
+  }
 
   const handleSubmit = useCallback((event: FormEvent<ExactPaymentForm>) => {
     event.preventDefault()
     exact?.payOrder()
   }, [exact])
 
-  //Prevent checkout with empty cart
+  const cleanupExactJS = () => {
+    exact?.reset();
+    exact = null
+  }
+
   useEffect(() => {
-    if (!store.order) {
+    if (store.order === null) {
+      // order not created => send home
       router.push('/')
+    } else {
+      configureExactJS()
+      return () => {
+        cleanupExactJS();
+      }
     }
-    console.log(`use effect: ${store.order?.orderId}`)
-    onExactJSReady()
-  }, [store.order?.orderId])
+  }, [])
 
   return (
     <>
-      <div className={styles.checkoutdisclaimer}>
-        <h1>Demonstration only.</h1>
-        <h2><a href="https://developer.exactpay.com/docs/test-cards/" target="_blank">TEST CARDS</a></h2>
-      </div>
+      <Disclaimer />
 
       <main className={styles.main}>
         <OrderTotal />
-        <div id="paymentForm" className={styles.hidden}>
+        <div id="paymentForm" className={styles.paymentForm}>
           <form id="myForm" action="api/receivePaymentId" method="post" onSubmit={handleSubmit}>
             <div>
               <label htmlFor="email">Email Address</label>
@@ -103,30 +117,7 @@ export default function Checkout() {
               <div id="cvdDiv" className={styles.cvddiv}></div>
             </div>
 
-            <div>
-              <label htmlFor="address">Address</label>
-              <input type="text" id="address" name="address" autoComplete="street-address" />
-            </div>
-
-            <div>
-              <label htmlFor="apartment">Apartment, suite, etc.</label>
-              <input type="text" id="apartment" name="apartment" />
-            </div>
-
-            <div>
-              <label htmlFor="city">City</label>
-              <input type="text" id="city" name="city" />
-            </div>
-
-            <div>
-              <label htmlFor="province">State</label>
-              <input type="text" id="province" name="province" />
-            </div>
-
-            <div>
-              <label htmlFor="postcode">Postal code</label>
-              <input type="text" id="postcode" name="postcode" autoComplete="postal-code" />
-            </div>
+            <div id="addressDiv" className={styles.paymentElement}></div>
 
             <input type="hidden" name="payment_id" id="payment_id"></input>
 
@@ -139,4 +130,3 @@ export default function Checkout() {
     </>
   )
 }
-

--- a/pay-from-browser/types.ts
+++ b/pay-from-browser/types.ts
@@ -1,94 +1,97 @@
 declare global {
-    let ExactJS: (key : string, locale? : {locale : string}) => Exact;
-  }
-export type Exact = {
-    components : (order : {orderId : string}) => Component,
-    payOrder : () => Promise<string>,
-    on : (paymentState : "payment-complete" | "payment-failed", functionCall: (payload :ExactJSPaymentPayload | ExactJSTokenPayload) => void) => void,
-    tokenize : () => void
+  let ExactJS: (key: string, locale?: { locale: string }) => Exact;
 }
-export type Component =  {
-    addCard : (divName : string, payload? : {"style"? : Styling, "wallets"? :boolean, label?: Label }) => void;
-    addComponent : (divName : string, divId: string, payload? : {"style"? : Styling, "wallets"? :boolean, label?: Label }) => void;
+export type Exact = {
+  components: (order: { orderId: string }) => Component,
+  payOrder: () => Promise<string>,
+  on: (paymentState: "payment-complete" | "payment-failed", functionCall: (payload: ExactJSPaymentPayload | ExactJSTokenPayload) => void) => void,
+  tokenize: () => void
+}
+export type Component = {
+  addCard: (divName: string, payload?: { "style"?: Styling, "wallets"?: boolean, label?: Label }) => void;
+  addComponent: (divName: string, divId: string, payload?: { "billingAddress"?: BillingAddress, "style"?: Styling, "wallets"?: boolean, label?: Label }) => void;
 }
 
 export type ExactJSPaymentPayload = {
-    paymentId : string 
+  paymentId: string
 }
 export type ExactJSTokenPayload = {
-    token : string
-    card_brand : string
-    last4 : string
-    expiry_month: string
-    expiry_year: string
+  token: string
+  card_brand: string
+  last4: string
+  expiry_month: string
+  expiry_year: string
 }
 
 
+export type BillingAddress = {
+  type: string
+}
 
 export type Label = {
-    //Labels
-    position: "above" | "inside" | "none"
+  //Labels
+  position: "above" | "inside" | "none"
 }
 export type Styling = {
-    
-    default: Style,
-    error?: Style,
-    
+
+  default: Style,
+  error?: Style,
+
 }
 export type Style = {
-    //General Styling
-    padding? : string,
-    color? : string,
-    fontFamily? : string,
-    fontSize? : string,
-    fontWeight? : string,
-    textAlign? : string,
-    textTransform? : string,
-    textShadow? : string,
-    fontStyle? :string,
+  //General Styling
+  padding?: string,
+  color?: string,
+  fontFamily?: string,
+  fontSize?: string,
+  fontWeight?: string,
+  textAlign?: string,
+  textTransform?: string,
+  textShadow?: string,
+  fontStyle?: string,
 
-    //Input Styling
-    backgroundColor? : string,
-    border? : string,
-    borderRadius? : string,
-    borderWidth? : string,
-    borderColor? : string,
+  //Input Styling
+  backgroundColor?: string,
+  border?: string,
+  borderRadius?: string,
+  borderWidth?: string,
+  borderColor?: string,
 
-    
+
 }
 
-export interface ExactPaymentForm extends HTMLFormElement{
-    closest : (form_name: string) => {
-        submit : () => void
-    }
+export interface ExactPaymentForm extends HTMLFormElement {
+  closest: (form_name: string) => {
+    submit: () => void
+  }
 }
 
 export type Data = {
-    token: string,
-    orderId : string
-  }
+  token: string,
+  orderId: string
+}
 
 export type PaymentInfo = {
 
-    id: string,
-    paymentId: string,
-    terminalId: string,
-    merchantId: string,
-    accountId: string,
-    type: string,
-    status: string,
-    approved: boolean,
-    captured: boolean,
-    voided: boolean,
-    refunded: boolean,
-    settled: boolean,
-    amount: number,
-    sentToBank: boolean,
-    createdAt: string
+  id: string,
+  paymentId: string,
+  terminalId: string,
+  merchantId: string,
+  accountId: string,
+  type: string,
+  status: string,
+  approved: boolean,
+  captured: boolean,
+  voided: boolean,
+  refunded: boolean,
+  settled: boolean,
+  amount: number,
+  sentToBank: boolean,
+  createdAt: string
 }
 
 export type TokenInfo = {
-    token : string,
-    orderId : string,
-    accountId : string
+  token: string,
+  orderId: string,
+  accountId: string
 }

--- a/pay-from-browser/types.ts
+++ b/pay-from-browser/types.ts
@@ -8,6 +8,7 @@ export type Exact = {
   tokenize: () => void
 }
 export type Component = {
+  remount: () => void;
   addCard: (divName: string, payload?: { "style"?: Styling, "wallets"?: boolean, label?: Label }) => void;
   addComponent: (divName: string, divId: string, payload?: { "billingAddress"?: BillingAddress, "style"?: Styling, "wallets"?: boolean, label?: Label }) => void;
 }
@@ -22,7 +23,6 @@ export type ExactJSTokenPayload = {
   expiry_month: string
   expiry_year: string
 }
-
 
 export type BillingAddress = {
   type: string
@@ -56,8 +56,6 @@ export type Style = {
   borderRadius?: string,
   borderWidth?: string,
   borderColor?: string,
-
-
 }
 
 export interface ExactPaymentForm extends HTMLFormElement {
@@ -66,13 +64,13 @@ export interface ExactPaymentForm extends HTMLFormElement {
   }
 }
 
-export type Data = {
+export type Order = {
   token: string,
-  orderId: string
+  orderId: string,
+  totalAmount: number
 }
 
 export type PaymentInfo = {
-
   id: string,
   paymentId: string,
   terminalId: string,

--- a/pay-from-browser/types.ts
+++ b/pay-from-browser/types.ts
@@ -5,10 +5,10 @@ export type Exact = {
   components: (order: { orderId: string }) => Component,
   payOrder: () => Promise<string>,
   on: (paymentState: "payment-complete" | "payment-failed", functionCall: (payload: ExactJSPaymentPayload | ExactJSTokenPayload) => void) => void,
-  tokenize: () => void
+  tokenize: () => void,
+  reset: () => void,
 }
 export type Component = {
-  remount: () => void;
   addCard: (divName: string, payload?: { "style"?: Styling, "wallets"?: boolean, label?: Label }) => void;
   addComponent: (divName: string, divId: string, payload?: { "billingAddress"?: BillingAddress, "style"?: Styling, "wallets"?: boolean, label?: Label }) => void;
 }
@@ -91,5 +91,9 @@ export type PaymentInfo = {
 export type TokenInfo = {
   token: string,
   orderId: string,
-  accountId: string
+  accountId: string,
+  cardBrand: string,
+  expiryMonth: string,
+  expiryYear: string,
+  last4: string
 }

--- a/pay-from-browser/util/useCartState.tsx
+++ b/pay-from-browser/util/useCartState.tsx
@@ -1,4 +1,5 @@
 import create from 'zustand';
+import { Order } from '../types';
 
 export type StoreItemProps = {
   itemnum: string;
@@ -7,12 +8,16 @@ export type StoreItemProps = {
 
 interface ItemState {
   items: StoreItemProps[];
+  order: Order | null;
   addItem: (item: StoreItemProps) => void;
   removeAllItems: () => void;
+  setOrder: (order: Order) => void;
 }
 
 export const useCartState = create<ItemState>((set) => ({
   items: [],
+  order: null,
   addItem: (item: StoreItemProps) => set((state) => ({ items: [...state.items, item] })),
   removeAllItems: () => set({ items: [] }),
+  setOrder: (order: Order) => set({ order: order }),
 }));

--- a/tokenize-from-browser/README.md
+++ b/tokenize-from-browser/README.md
@@ -8,6 +8,7 @@ The checkout page displays a form which uses ExactJS, this shop uses tokenized p
 This program requires a `.env.local` with the following: 
 - P2_ACCOUNT_ID: Your Account ID
 - APPLICATION_TOKEN: An application token generated for the Exact Payments API
+- NEXT_PUBLIC_P2_DOMAIN: The P2 domain to which API requests should be sent (do not include scheme - HTTPS is mandatory!!), eg: api.exactpaysandbox.com
 - NEXT_PUBLIC_BASE_URL: set to `http://localhost:3000` for local development- something else if you are deploying somewhere.
 
 Run the following to start a development instance of the app.
@@ -90,7 +91,7 @@ We send the user back to the index page if they are in an illegal state for chec
 A copy of the checkout page, but with a bullet ui created by setting individual elements.
 
 #### `paid.tsx`
-A demo post-payment screen.
+A straightforward post-payment screen.
 
 **OPTIONAL:**
 

--- a/tokenize-from-browser/components/Cart.tsx
+++ b/tokenize-from-browser/components/Cart.tsx
@@ -1,30 +1,24 @@
 import { FC } from "react"
-import { useCartState } from "../util/useCartState"
+import { useCartState, StoreItemProps } from "../util/useCartState"
 import Image from "next/image"
 import styles from '../styles/Home.module.css'
 
-type CartItemProps = {
-    itemnum: string
-  
-  }
-
-const CartItem : FC<CartItemProps> = (props : CartItemProps) => {
-  return(
-    <Image src={`/plants/${props.itemnum}.jpg`} width={100} height={100} alt= {`plant${props.itemnum}`} className={styles.card} />
+const CartItem: FC<StoreItemProps> = (props: StoreItemProps) => {
+  return (
+    <Image src={`/plants/${props.itemnum}.jpg`} width={100} height={100} alt={`plant${props.itemnum}`} className={styles.card} />
   )
 }
 
-const Cart : FC<{}> = () => {
+const Cart: FC<{}> = () => {
   const store = useCartState()
-    return (
-      <>
+  return (
+    <>
       {store.items.map(item => {
-        return <CartItem itemnum={item} key={Math.random()}/>
+        return <CartItem itemnum={item.itemnum} price={0} />
       })}
-      
-      </>
-    )
-  
+    </>
+  )
+
 }
 
 export default Cart

--- a/tokenize-from-browser/components/Cart.tsx
+++ b/tokenize-from-browser/components/Cart.tsx
@@ -14,7 +14,7 @@ const Cart: FC<{}> = () => {
   return (
     <>
       {store.items.map(item => {
-        return <CartItem itemnum={item.itemnum} price={0} />
+        return <CartItem key={item.itemnum} itemnum={item.itemnum} price={0} />
       })}
     </>
   )

--- a/tokenize-from-browser/components/CheckoutButton.tsx
+++ b/tokenize-from-browser/components/CheckoutButton.tsx
@@ -1,22 +1,73 @@
-import { useCartState } from '../util/useCartState'
+import { useRouter } from "next/router";
 import Link from 'next/link'
+import { useCartState } from '../util/useCartState'
 import styles from '../styles/Home.module.css'
 import { useState } from 'react'
 import Switch from 'react-switch'
+import axios from 'axios'
+import { totalPrice } from './OrderTotal'
+import { Order } from "../types";
 
-const CheckoutButton  = () => {
-    const store = useCartState()
-    const isEmpty = store.items.length == 0
+const CheckoutButton = () => {
+  const router = useRouter();
+  const store = useCartState()
+  const isEmpty = store.items.length == 0
   const [altCheckoutSelected, setAltCheckoutSelected] = useState(false);
 
-    return (
-      isEmpty ? <></> : <>
-      <div className={styles.switch}>
-          <Switch checked={altCheckoutSelected} onChange={setAltCheckoutSelected} onColor='#7ac833' offColor= '#000000' activeBoxShadow='7ac833' uncheckedIcon={false} checkedIcon={false}/>
-          <p className={altCheckoutSelected ? styles.switchlabelgreen :'' }>Alternate Checkout UI</p>
-      </div>
-      <Link href= {altCheckoutSelected ? 'checkout2' : 'checkout'} className={styles.card}>Checkout</Link>
-      </>
-    )
+  const createOrUpdateOrder = (event: any) => {
+    event.preventDefault();
+    const order = store.order
+    if (order == null) {
+      createOrder(event.target.href);
+    } else {
+      updateOrder(order, event.target.href);
+    }
   }
+
+  const createOrder = (nextLocation: string) => {
+    const url = process.env.NEXT_PUBLIC_BASE_URL + '/api/createOrder'
+
+    const amount = totalPrice(store.items); //Price is in cents
+    axios.post(url, {
+      amount: amount
+    }).then((response) => {
+      console.debug("Order created")
+      store.setOrder({
+        token: response.data.token,
+        orderId: response.data.orderId,
+        totalAmount: amount
+      })
+      router.push(nextLocation)
+    })
+  }
+
+  const updateOrder = (order: Order, nextLocation: string) => {
+    const url = process.env.NEXT_PUBLIC_BASE_URL + '/api/updateOrder'
+
+    const amount = totalPrice(store.items); //Price is in cents
+    if (amount !== order.totalAmount) {
+      axios.post(url, {
+        orderId: store.order?.orderId,
+        amount: amount
+      }).then((response) => {
+        console.debug("Order updated")
+        order.totalAmount = response.data.amount
+        store.setOrder(order)
+        router.push(nextLocation)
+      })
+    } else {
+      router.push(nextLocation)
+    }
+  }
+
+  return (
+    isEmpty ? <></> : <>
+      <div className={styles.switch}>
+        <Switch checked={altCheckoutSelected} onChange={setAltCheckoutSelected} onColor='#7ac833' offColor='#000000' activeBoxShadow='7ac833' uncheckedIcon={false} checkedIcon={false} />
+        <p className={altCheckoutSelected ? styles.switchlabelgreen : ''}>Alternate Checkout UI</p>
+      </div>
+      <Link href={altCheckoutSelected ? 'checkout2' : 'checkout'} className={styles.card} onClick={createOrUpdateOrder}>Checkout</Link>
+    </>
+  )
+}
 export default CheckoutButton  

--- a/tokenize-from-browser/components/CheckoutButton.tsx
+++ b/tokenize-from-browser/components/CheckoutButton.tsx
@@ -12,8 +12,8 @@ const CheckoutButton  = () => {
     return (
       isEmpty ? <></> : <>
       <div className={styles.switch}>
-          <Switch checked={altCheckoutSelected} onChange={setAltCheckoutSelected} onColor='#d8908f' offColor= '#000000' activeBoxShadow='7ac833' uncheckedIcon={false} checkedIcon={false}/>
-          <p className={altCheckoutSelected ? styles.switchlabelgreen :'' }>{altCheckoutSelected ? "2" : "1"}-Pass Payment</p>
+          <Switch checked={altCheckoutSelected} onChange={setAltCheckoutSelected} onColor='#7ac833' offColor= '#000000' activeBoxShadow='7ac833' uncheckedIcon={false} checkedIcon={false}/>
+          <p className={altCheckoutSelected ? styles.switchlabelgreen :'' }>Alternate Checkout UI</p>
       </div>
       <Link href= {altCheckoutSelected ? 'checkout2' : 'checkout'} className={styles.card}>Checkout</Link>
       </>

--- a/tokenize-from-browser/components/Disclaimer.tsx
+++ b/tokenize-from-browser/components/Disclaimer.tsx
@@ -1,0 +1,13 @@
+import styles from '../styles/Home.module.css'
+
+const Disclaimer = () => {
+  return (
+    <div className={styles.checkoutdisclaimer}>
+      <h1>Demonstration only.</h1>
+      <h2>Payments are simulated and no actual funds are transferred.</h2>
+      <h2><a href="https://developer.exactpay.com/docs/Sandbox-Test-Cards" target="_blank">TEST CARDS</a></h2>
+    </div>
+  )
+};
+
+export default Disclaimer

--- a/tokenize-from-browser/components/OrderTotal.tsx
+++ b/tokenize-from-browser/components/OrderTotal.tsx
@@ -1,14 +1,17 @@
-import { useCartState } from "../util/useCartState"
+import { StoreItemProps, useCartState } from "../util/useCartState"
 
-const OrderTotal = () => {
-    const items = useCartState().items
+export const totalPrice = (items: StoreItemProps[]) => {
+  return items.map(item => item.price).reduce((total, price) => total + price, 0)
+}
 
+export const OrderTotal = () => {
+  const items = useCartState().items
 
-    const getFormattedPrice = () => {
-        return "$" + (items.length*10) + ".00"
-    }
+  const getFormattedPrice = () => {
+    return "$" + (totalPrice(items) / 100)
+  }
 
-    return (<h3>Your Order Total: {getFormattedPrice()}</h3>)
+  return (<h3>Your Order Total: {getFormattedPrice()}</h3>)
 }
 
 export default OrderTotal

--- a/tokenize-from-browser/components/PaymentInfoBox.tsx
+++ b/tokenize-from-browser/components/PaymentInfoBox.tsx
@@ -9,11 +9,26 @@ interface PaymentInformation {
     const { paymentInfo } = props;
 
     return (<>
+        
         <h4>paymentInfo: </h4><br></br>
+        <code>
+            POST /account/{paymentInfo.accountId}/payments/{paymentInfo.paymentId}
+        </code><br></br>
+        <br></br>
         <code>id: {paymentInfo.id}</code><br></br>
         <code>paymentId: {paymentInfo.paymentId}</code><br></br>
+        <code>terminalId: {paymentInfo.terminalId}</code><br></br>
+        <code>merchantId: {paymentInfo.merchantId}</code><br></br>
+        <code>type: {paymentInfo.type}</code><br></br>
         <code>status: {paymentInfo.status}</code><br></br>
+        <code>approved: {String(paymentInfo.approved)}</code><br></br>
+        <code>captured: {String(paymentInfo.captured)}</code><br></br>
+        <code>voided: {String(paymentInfo.voided)}</code><br></br>
+        <code>refunded: {String(paymentInfo.refunded)}</code><br></br>
+        <code>settled: {String(paymentInfo.settled)}</code><br></br>
         <code>amount (cents): {paymentInfo.amount}</code><br></br>
+        <code>sentToBank: {String(paymentInfo.sentToBank)}</code><br></br>
+        <code>createdAt: {paymentInfo.createdAt}</code><br></br>
     </>);
 };
 export default PaymentInfoBox

--- a/tokenize-from-browser/components/StoreItem.tsx
+++ b/tokenize-from-browser/components/StoreItem.tsx
@@ -1,19 +1,18 @@
 import Image from 'next/image';
 import { FC } from 'react';
 import styles from '../styles/Home.module.css';
-import { useCartState } from '../util/useCartState';
-
-type StoreItemProps = {
-  itemnum: string;
-};
+import { useCartState, StoreItemProps } from '../util/useCartState';
 
 export const StoreItem: FC<StoreItemProps> = (props: StoreItemProps) => {
   const store = useCartState();
   const handleOnClick = () => {
-    store.addItem(props.itemnum);
+    store.addItem(props);
   };
   return (
-    <Image src={`/plants/${props.itemnum}.jpg`} width={300} height={300} alt={`plant${props.itemnum}`} className={styles.card} onClick={handleOnClick} />
+    <div className={styles.card}>
+      <Image src={`/plants/${props.itemnum}.jpg`} width={250} height={250} alt={`plant${props.itemnum}`} onClick={handleOnClick} />
+      $ {props.price / 100}
+    </div>
   );
 };
 export default StoreItem

--- a/tokenize-from-browser/package.json
+++ b/tokenize-from-browser/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev -p 4000",
     "build": "next build",
     "start": "next start",
     "lint": "next lint"

--- a/tokenize-from-browser/pages/_app.tsx
+++ b/tokenize-from-browser/pages/_app.tsx
@@ -2,12 +2,11 @@ import '../styles/globals.css'
 import type { AppProps } from 'next/app'
 import Script from 'next/script'
 
-
 export default function App({ Component, pageProps }: AppProps) {
+  const exactJsSource = `https://${process.env.NEXT_PUBLIC_P2_DOMAIN}/js/v1/exact.js`
+
   return <>
-    <Script src="https://api.exactpaysandbox.com/js/v1/exact.js" />
-
-
+    <Script src={exactJsSource} />
     <Component {...pageProps} />
   </>
 }

--- a/tokenize-from-browser/pages/api/createOrder.ts
+++ b/tokenize-from-browser/pages/api/createOrder.ts
@@ -2,11 +2,9 @@ import type { NextApiRequest, NextApiResponse } from 'next'
 import axios from 'axios'
 import { AxiosRequestConfig } from 'axios'
 
-import { Data } from '../../types'
-
 export default async function handler(
   req: NextApiRequest,
-  res: NextApiResponse<Data>
+  res: NextApiResponse
 ) {
   const options: AxiosRequestConfig = {
     method: 'POST',
@@ -17,7 +15,7 @@ export default async function handler(
       authorization: process.env.APPLICATION_TOKEN
     },
     data: {
-      ...req.body,
+      amount: req.body.amount,
       reference: { referenceNo: "sample for demo" }
     }
   };

--- a/tokenize-from-browser/pages/api/demoPayWithToken.ts
+++ b/tokenize-from-browser/pages/api/demoPayWithToken.ts
@@ -6,25 +6,25 @@ export default async function handler(
   res: NextApiResponse
 ) {
   const options = {
-      method: 'GET',
-      url: `https://api.exactpaysandbox.com/account/${process.env.accountId}/orders/${process.env.orderId}`,
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: process.env.APPLICATION_TOKEN
-      }
-    };
-  
-     await axios.request(options).then(function (response) {
-      // console.log(response.data);
-       console.log(req.body)
-       res.json(response.data);
-       res.status(200)
+    method: 'GET',
+    url: `https://${process.env.NEXT_PUBLIC_P2_DOMAIN}/account/${process.env.accountId}/orders/${process.env.orderId}`,
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: process.env.APPLICATION_TOKEN
+    }
+  };
 
-     }).catch(function (error) {
-       console.error(error);
-       res.status(501)
-       res.end()
-     });
-  
-    // }
+  await axios.request(options).then(function (response) {
+    // console.log(response.data);
+    console.log(req.body)
+    res.json(response.data);
+    res.status(200)
+
+  }).catch(function (error) {
+    console.error(error);
+    res.status(501)
+    res.end()
+  });
+
+  // }
 }

--- a/tokenize-from-browser/pages/api/postOrders.ts
+++ b/tokenize-from-browser/pages/api/postOrders.ts
@@ -1,17 +1,16 @@
 import type { NextApiRequest, NextApiResponse } from 'next'
 import axios from 'axios'
-import {AxiosRequestConfig} from 'axios'
+import { AxiosRequestConfig } from 'axios'
 
-import {Data} from '../../types'
-
+import { Data } from '../../types'
 
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse<Data>
 ) {
-  const options : AxiosRequestConfig = {
+  const options: AxiosRequestConfig = {
     method: 'POST',
-    url: `https://api.exactpaysandbox.com/account/${process.env.P2_ACCOUNT_ID}/orders`,
+    url: `https://${process.env.NEXT_PUBLIC_P2_DOMAIN}/account/${process.env.P2_ACCOUNT_ID}/orders`,
     headers: {
       accept: 'application/json',
       'content-type': 'application/json',
@@ -19,24 +18,21 @@ export default async function handler(
     },
     data: {
       ...req.body,
-      reference: {referenceNo: "sample for demo"}
+      reference: { referenceNo: "sample for demo" }
     }
   };
   await axios
     .request(options)
-    .then( (response) => {
+    .then((response) => {
       res.status(200)
-      console.log(response.data)
       res.json({
-        token : response.data.accessToken.token,
-        orderId : response.data.id
+        token: response.data.accessToken.token,
+        orderId: response.data.id
       })
-
     })
-    .catch( (error) => {
+    .catch((error) => {
       console.error(error);
       res.status(401)
       res.end()
     });
-  
 }

--- a/tokenize-from-browser/pages/api/receiveTokenAndPay.ts
+++ b/tokenize-from-browser/pages/api/receiveTokenAndPay.ts
@@ -5,10 +5,9 @@ import axios from 'axios';
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
-)
-{
+) {
 
-  if (!req.body.token || !req.body.order_id){
+  if (!req.body.token || !req.body.order_id) {
     res.status(400).end()
   }
   console.log("\n\n PAYMENT FORM DATA: \n")
@@ -18,21 +17,21 @@ export default async function handler(
   console.log(req.body.token)
   console.log("\n\n")
 
-    //Here we save orderId to simulate a database
-    process.env.orderId = req.body.order_id
+  //Here we save orderId to simulate a database
+  process.env.orderId = req.body.order_id
 
-    //Here we pay for order on the backend
-    const options = {
-      method: 'POST',
-      url: `https://api.exactpaysandbox.com/account/${process.env.P2_ACCOUNT_ID}/orders/${req.body.order_id}/pay`,
-      headers: {
-        accept: 'application/json', 
-        'content-type': 'application/json',
-        authorization: process.env.APPLICATION_TOKEN
-      },
-      data: {payment_method: {token: req.body.token}}
-    };
-    axios
+  //Here we pay for order on the backend
+  const options = {
+    method: 'POST',
+    url: `https://${process.env.NEXT_PUBLIC_P2_DOMAIN}/account/${process.env.P2_ACCOUNT_ID}/orders/${req.body.order_id}/pay`,
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      authorization: process.env.APPLICATION_TOKEN
+    },
+    data: { payment_method: { token: req.body.token } }
+  };
+  axios
     .request(options)
     .then(function (response) {
       console.log("\n\nRESPONSE FROM API:\n");
@@ -41,5 +40,5 @@ export default async function handler(
     .catch(function (error) {
       console.error(error);
     });
-    res.redirect(302, `/paid`)
+  res.redirect(302, `/paid`)
 }

--- a/tokenize-from-browser/pages/api/receiveTokenAndPrint.ts
+++ b/tokenize-from-browser/pages/api/receiveTokenAndPrint.ts
@@ -6,21 +6,20 @@ import axios from 'axios';
 export default async function handler(
   req: NextApiRequest,
   res: NextApiResponse
-)
-{
+) {
 
-  if (!req.body.token || !req.body.order_id){
+  if (!req.body.token || !req.body.order_id) {
     res.status(400).end()
   }
   console.log(req.body)
 
-    //Here we save orderId & token to simulate a database
-    process.env.orderId = req.body.order_id
-    process.env.token = req.body.token
-    process.env.cardBrand = req.body.card_brand 
-    process.env.expiryMonth = req.body.expiry_month 
-    process.env.expiryYear = req.body.expiry_year 
-    process.env.last4 = req.body.last4
+  //Here we save orderId & token to simulate a database
+  process.env.orderId = req.body.order_id
+  process.env.token = req.body.token
+  process.env.cardBrand = req.body.card_brand
+  process.env.expiryMonth = req.body.expiry_month
+  process.env.expiryYear = req.body.expiry_year
+  process.env.last4 = req.body.last4
 
-    res.redirect(302, `/token`)
+  res.redirect(302, `/token`)
 }

--- a/tokenize-from-browser/pages/api/updateOrder.ts
+++ b/tokenize-from-browser/pages/api/updateOrder.ts
@@ -1,0 +1,34 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import axios from 'axios'
+import { AxiosRequestConfig } from 'axios'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  const options: AxiosRequestConfig = {
+    method: 'PUT',
+    url: `https://${process.env.NEXT_PUBLIC_P2_DOMAIN}/account/${process.env.P2_ACCOUNT_ID}/orders/${req.body.orderId}`,
+    headers: {
+      accept: 'application/json',
+      'content-type': 'application/json',
+      authorization: process.env.APPLICATION_TOKEN
+    },
+    data: {
+      amount: req.body.amount,
+    }
+  };
+  await axios
+    .request(options)
+    .then(() => {
+      res.status(200)
+      res.json({
+        amount: req.body.amount
+      })
+    })
+    .catch((error) => {
+      console.error(error);
+      res.status(401)
+      res.end()
+    });
+}

--- a/tokenize-from-browser/pages/checkout.tsx
+++ b/tokenize-from-browser/pages/checkout.tsx
@@ -1,114 +1,100 @@
+import { FormEvent, useEffect } from "react"
+import { useRouter } from "next/router"
+
 import { useCartState } from "../util/useCartState"
-import { totalPrice, OrderTotal } from "../components/OrderTotal"
+import { OrderTotal } from "../components/OrderTotal"
+import Disclaimer from "../components/Disclaimer"
 
 import styles from '../styles/Home.module.css'
-
-import Script from 'next/script'
-import axios from 'axios'
-import { FormEvent, useEffect } from "react"
-import { MutatingDots } from "react-loader-spinner"
-import { useRouter } from "next/router"
 
 import { Exact, ExactJSTokenPayload, ExactPaymentForm } from '../types'
 
 export default function Checkout() {
-  let exact: Exact;
+  let exact: Exact | null = null
 
-  const exactJsSource = `https://${process.env.NEXT_PUBLIC_P2_DOMAIN}/js/v1/exact.js`
+  const router = useRouter()
+  const store = useCartState()
 
-  const items = useCartState().items
+  const configureExactJS = () => {
+    exact = ExactJS(store.order?.token as string)
+    const components = exact.components({ orderId: store.order?.orderId as string })
 
-  const setOrderPosted = () => {
-    (document.getElementById('hideable')! as HTMLInputElement).className = "";
-    (document.getElementById('loading')! as HTMLInputElement).className = styles.hidden;
+    components.addCard('cardElement', {
+      label: { position: "above" },
+      style: {
+        default: {
+          padding: '2px',
+          border: "1px solid #ccc",
+          fontSize: "14px",
+          backgroundColor: "#b6bdcb"
+        },
+      }
+    });
+
+    components.addComponent('addressElement', 'address', {
+      billingAddress: {
+        type: "minimal",
+      },
+      label: { position: "above" },
+      style: {
+        default: {
+          padding: '2px',
+          border: "1px solid #ccc",
+          fontSize: "14px",
+          backgroundColor: "#b6bdcb"
+        },
+      }
+    });
+
+    exact.on("payment-complete", (payload: unknown) => {
+      const tokenPayload = payload as ExactJSTokenPayload
+      console.debug(`MERCHANT payment-complete: ${JSON.stringify(payload)}`);
+      (document.getElementById('token')! as HTMLInputElement).value = tokenPayload.token;
+      (document.getElementById('card_brand')! as HTMLInputElement).value = tokenPayload.card_brand;
+      (document.getElementById('expiry_month')! as HTMLInputElement).value = tokenPayload.expiry_month;
+      (document.getElementById('expiry_year')! as HTMLInputElement).value = tokenPayload.expiry_year;
+      (document.getElementById('last4')! as HTMLInputElement).value = tokenPayload.last4;
+      (document.getElementById('order_id')! as HTMLInputElement).value = store.order?.orderId as string;
+      (document.getElementById('myForm') as HTMLFormElement).submit();
+    });
+
+    exact.on("payment-failed", (payload) => {
+      console.debug(`MERCHANT payment failed: ${JSON.stringify(payload)}`);
+    });
   }
-
-  const onExactJSReady = () => {
-    const url = process.env.NEXT_PUBLIC_BASE_URL + '/api/postOrders'
-    axios.post(url, {
-      amount: totalPrice(items), //Price is in cents
-    }).then(
-      (response) => {
-        exact = ExactJS(response.data.token)
-        const components = exact.components({ orderId: response.data.orderId });
-        components.addCard('cardElement', {
-          label: { position: "above" },
-          style: {
-            default: {
-              padding: '2px',
-              border: "1px solid #ccc",
-              fontSize: "14px",
-              backgroundColor: "#b6bdcb"
-            },
-          }
-        });
-
-        components.addComponent('addressElement', 'address', {
-          billingAddress: {
-            type: "minimal",
-          },
-          label: { position: "above" },
-          style: {
-            default: {
-              padding: '2px',
-              border: "1px solid #ccc",
-              fontSize: "14px",
-              backgroundColor: "#b6bdcb"
-            },
-          }
-        });
-
-        exact.on("payment-complete", (payload: unknown) => {
-          const tokenPayload = payload as ExactJSTokenPayload
-          console.debug(`MERCHANT payment-complete: ${JSON.stringify(payload)}`);
-          (document.getElementById('token')! as HTMLInputElement).value = tokenPayload.token;
-          (document.getElementById('card_brand')! as HTMLInputElement).value = tokenPayload.card_brand;
-          (document.getElementById('expiry_month')! as HTMLInputElement).value = tokenPayload.expiry_month;
-          (document.getElementById('expiry_year')! as HTMLInputElement).value = tokenPayload.expiry_year;
-          (document.getElementById('last4')! as HTMLInputElement).value = tokenPayload.last4;
-          (document.getElementById('order_id')! as HTMLInputElement).value = response.data.orderId;
-          (document.getElementById('myForm') as HTMLFormElement).submit();
-        });
-
-        exact.on("payment-failed", (payload) => {
-          console.debug(`MERCHANT payment failed: ${JSON.stringify(payload)}`);
-        });
-
-        setTimeout(setOrderPosted, 1100);
-      })
-  }
-
 
   const handleSubmit = (event: FormEvent<ExactPaymentForm>) => {
     event.preventDefault()
-    exact.tokenize()
-    return false
+    exact?.tokenize()
   }
 
-  //Prevent checkout with empty cart
-  const router = useRouter()
+  const cleanupExactJS = () => {
+    exact?.reset();
+    exact = null
+  }
+
   useEffect(() => {
-    if (!items) {
+    if (store.order === null) {
+      // order not created => send home
       router.push('/')
+    } else {
+      configureExactJS()
+      return () => {
+        cleanupExactJS();
+      }
     }
-  })
+  }, [])
 
   return (
     <>
       <div className={styles.checkoutdisclaimer}>
         <h1>1-Pass Tokenized Payment</h1>
-        <h2><a href="https://developer.exactpay.com/docs/test-cards/" target="_blank">TEST CARDS</a></h2>
-      </div>
+      </div >
 
+      <Disclaimer />
       <main className={styles.main}>
         <OrderTotal />
-        <div id="loading">
-          <MutatingDots height="100" width="100" color="#d8908f" secondaryColor='#d8908f' radius='12.5' ariaLabel="mutating-dots-loading" />
-
-          <Script src={exactJsSource} strategy="afterInteractive" onReady={onExactJSReady} />
-        </div>
-
-        <div id="hideable" className={styles.hidden}>
+        <div id="paymentForm" className={styles.paymentForm}>
           <form id="myForm" action="api/receiveTokenAndPay" method="post" onSubmit={handleSubmit}>
             <div>
               <label htmlFor="email">Email Address</label>

--- a/tokenize-from-browser/pages/checkout.tsx
+++ b/tokenize-from-browser/pages/checkout.tsx
@@ -1,4 +1,5 @@
 import { useCartState } from "../util/useCartState"
+import { totalPrice, OrderTotal } from "../components/OrderTotal"
 
 import styles from '../styles/Home.module.css'
 
@@ -7,127 +8,115 @@ import axios from 'axios'
 import { FormEvent, useEffect } from "react"
 import { MutatingDots } from "react-loader-spinner"
 import { useRouter } from "next/router"
-import OrderTotal from "../components/OrderTotal"
 
-import {Exact, ExactJSTokenPayload, ExactPaymentForm } from '../types'
+import { Exact, ExactJSTokenPayload, ExactPaymentForm } from '../types'
 
-export default  function Checkout() {
-    let exact : Exact;
+export default function Checkout() {
+  let exact: Exact;
 
-    const items = useCartState().items
-      
-    const getTotalPrice = () => {
-        return  items.length * 1000
-    }
+  const exactJsSource = `https://${process.env.NEXT_PUBLIC_P2_DOMAIN}/js/v1/exact.js`
 
-    const setOrderPosted = () => {
-        (document.getElementById('hideable')! as HTMLInputElement).className = "";
-        (document.getElementById('loading')! as HTMLInputElement).className = styles.hidden;
-    }
-    
-    const  onExactJSReady = () => {
-        const url = process.env.NEXT_PUBLIC_BASE_URL + '/api/postOrders'
-        axios.post(url, {
-        amount: getTotalPrice(), //Price is in cents
+  const items = useCartState().items
+
+  const setOrderPosted = () => {
+    (document.getElementById('hideable')! as HTMLInputElement).className = "";
+    (document.getElementById('loading')! as HTMLInputElement).className = styles.hidden;
+  }
+
+  const onExactJSReady = () => {
+    const url = process.env.NEXT_PUBLIC_BASE_URL + '/api/postOrders'
+    axios.post(url, {
+      amount: totalPrice(items), //Price is in cents
     }).then(
-         (response) => {
-            exact = ExactJS(response.data.token)
-            const components = exact.components({orderId: response.data.orderId});
-            components.addCard('cardElement', {
-                label: {position: "above"},
-                style: {
-                    default: {
-                        padding: '2px',
-                        border: "1px solid #ccc",
-                        fontSize: "14px",
-                        backgroundColor: "#b6bdcb"
-                      },
-                }});
+      (response) => {
+        exact = ExactJS(response.data.token)
+        const components = exact.components({ orderId: response.data.orderId });
+        components.addCard('cardElement', {
+          label: { position: "above" },
+          style: {
+            default: {
+              padding: '2px',
+              border: "1px solid #ccc",
+              fontSize: "14px",
+              backgroundColor: "#b6bdcb"
+            },
+          }
+        });
+
+        components.addComponent('addressElement', 'address', {
+          billingAddress: {
+            type: "minimal",
+          },
+          label: { position: "above" },
+          style: {
+            default: {
+              padding: '2px',
+              border: "1px solid #ccc",
+              fontSize: "14px",
+              backgroundColor: "#b6bdcb"
+            },
+          }
+        });
+
+        exact.on("payment-complete", (payload: unknown) => {
+          const tokenPayload = payload as ExactJSTokenPayload
+          console.debug(`MERCHANT payment-complete: ${JSON.stringify(payload)}`);
+          (document.getElementById('token')! as HTMLInputElement).value = tokenPayload.token;
+          (document.getElementById('card_brand')! as HTMLInputElement).value = tokenPayload.card_brand;
+          (document.getElementById('expiry_month')! as HTMLInputElement).value = tokenPayload.expiry_month;
+          (document.getElementById('expiry_year')! as HTMLInputElement).value = tokenPayload.expiry_year;
+          (document.getElementById('last4')! as HTMLInputElement).value = tokenPayload.last4;
+          (document.getElementById('order_id')! as HTMLInputElement).value = response.data.orderId;
+          (document.getElementById('myForm') as HTMLFormElement).submit();
+        });
+
+        exact.on("payment-failed", (payload) => {
+          console.debug(`MERCHANT payment failed: ${JSON.stringify(payload)}`);
+        });
+
+        setTimeout(setOrderPosted, 1100);
+      })
+  }
 
 
-            exact.on("payment-complete", (payload : unknown) => {
-                const tokenPayload = payload as ExactJSTokenPayload
-                (document.getElementById('token')! as HTMLInputElement).value  = tokenPayload.token;
-                (document.getElementById('card_brand')! as HTMLInputElement).value  = tokenPayload.card_brand;
-                (document.getElementById('expiry_month')! as HTMLInputElement).value  = tokenPayload.expiry_month;
-                (document.getElementById('expiry_year')! as HTMLInputElement).value  = tokenPayload.expiry_year;
-                (document.getElementById('last4')! as HTMLInputElement).value  = tokenPayload.last4;
-                (document.getElementById('order_id')! as HTMLInputElement).value = response.data.orderId;
-                (document.getElementById('myForm') as HTMLFormElement).submit();
-            });
-            
-            exact.on("payment-failed", (payload) => {
-                console.debug(payload);
-            });
-            setTimeout(setOrderPosted, 1100);
-        })
+  const handleSubmit = (event: FormEvent<ExactPaymentForm>) => {
+    event.preventDefault()
+    exact.tokenize()
+    return false
+  }
+
+  //Prevent checkout with empty cart
+  const router = useRouter()
+  useEffect(() => {
+    if (!items) {
+      router.push('/')
     }
+  })
 
-    
-    const handleSubmit = (event : FormEvent<ExactPaymentForm>) => {
-        event.preventDefault()
-        exact.tokenize()
-        return false
-    }
-
-    //Prevent checkout with empty cart
-    const router = useRouter()
-    useEffect(() => {
-        if (!getTotalPrice()){
-            router.push('/')
-        }
-    })
-
-    return (
+  return (
     <>
-    <div className={styles.checkoutdisclaimer}>
+      <div className={styles.checkoutdisclaimer}>
         <h1>1-Pass Tokenized Payment</h1>
         <h2><a href="https://developer.exactpay.com/docs/test-cards/" target="_blank">TEST CARDS</a></h2>
-    </div>
-    
-    <main className={styles.main}>
-        <OrderTotal/>
-        <div id="loading">
-            <MutatingDots height="100" width="100" color="#d8908f" secondaryColor= '#d8908f' radius='12.5' ariaLabel="mutating-dots-loading"/>
+      </div>
 
-            <Script src="https://api.exactpaysandbox.com/js/v1/exact.js" strategy="afterInteractive" onReady={onExactJSReady}/>
+      <main className={styles.main}>
+        <OrderTotal />
+        <div id="loading">
+          <MutatingDots height="100" width="100" color="#d8908f" secondaryColor='#d8908f' radius='12.5' ariaLabel="mutating-dots-loading" />
+
+          <Script src={exactJsSource} strategy="afterInteractive" onReady={onExactJSReady} />
         </div>
 
         <div id="hideable" className={styles.hidden}>
-        <form id="myForm" action="api/receiveTokenAndPay" method="post" onSubmit={handleSubmit}>
+          <form id="myForm" action="api/receiveTokenAndPay" method="post" onSubmit={handleSubmit}>
             <div>
-                <label htmlFor="email">Email Address</label>
-                <input type="email" id="email" name="email" autoComplete="email" />
+              <label htmlFor="email">Email Address</label>
+              <input type="email" id="email" name="email" autoComplete="email" />
             </div>
 
-            <div id="cardElement" >
-
-            </div>
-
-            <div>
-                <label htmlFor="address">Address</label>
-                <input type="text" id="address" name="address" autoComplete="street-address" />
-            </div>
-
-            <div>
-                <label htmlFor ="apartment">Apartment, suite, etc.</label>
-                <input type="text" id="apartment" name="apartment" />
-            </div>
-
-            <div>
-                <label htmlFor="city">City</label>
-                <input type="text" id="city" name="city" />
-            </div>
-
-            <div>
-                <label htmlFor="province">State</label>
-                <input type="text" id="province" name="province" />
-            </div>
-
-            <div>
-                <label htmlFor="postcode">Postal code</label>
-                <input type="text" id="postcode" name="postcode" autoComplete="postal-code" />
-            </div>
+            <div id="cardElement" ></div>
+            <div id="addressElement" ></div>
 
             <input type="hidden" name="token" id="token"></input>
             <input type="hidden" name="card_brand" id="card_brand"></input>
@@ -137,13 +126,12 @@ export default  function Checkout() {
             <input type="hidden" name="order_id" id="order_id"></input>
 
             <div>
-                <input type="submit" name="commit" value="Pay Now" data-disable-with="Pay Now" />
+              <input type="submit" name="commit" value="Pay Now" data-disable-with="Pay Now" />
             </div>
-        </form>
+          </form>
         </div>
-    </main>
+      </main>
     </>
-    )
+  )
 }
 
-  

--- a/tokenize-from-browser/pages/checkout2.tsx
+++ b/tokenize-from-browser/pages/checkout2.tsx
@@ -7,127 +7,115 @@ import axios from 'axios'
 import { FormEvent, useEffect } from "react"
 import { MutatingDots } from "react-loader-spinner"
 import { useRouter } from "next/router"
-import OrderTotal from "../components/OrderTotal"
+import OrderTotal, { totalPrice } from "../components/OrderTotal"
 
-import {Exact, ExactJSTokenPayload, ExactPaymentForm } from '../types'
+import { Exact, ExactJSTokenPayload, ExactPaymentForm } from '../types'
 
-export default  function Checkout() {
-    let exact : Exact;
+export default function Checkout() {
+  let exact: Exact;
 
-    const items = useCartState().items
-      
-    const getTotalPrice = () => {
-        return  items.length * 1000
-    }
+  const exactJsSource = `https://${process.env.NEXT_PUBLIC_P2_DOMAIN}/js/v1/exact.js`
 
-    const setOrderPosted = () => {
-        (document.getElementById('hideable')! as HTMLInputElement).className = "";
-        (document.getElementById('loading')! as HTMLInputElement).className = styles.hidden;
-    }
-    
-    const  onExactJSReady = () => {
-        const url = process.env.NEXT_PUBLIC_BASE_URL + '/api/postOrders'
-        axios.post(url, {
-        amount: getTotalPrice(), //Price is in cents
+  const items = useCartState().items
+
+  const setOrderPosted = () => {
+    (document.getElementById('hideable')! as HTMLInputElement).className = "";
+    (document.getElementById('loading')! as HTMLInputElement).className = styles.hidden;
+  }
+
+  const onExactJSReady = () => {
+    const url = process.env.NEXT_PUBLIC_BASE_URL + '/api/postOrders'
+    axios.post(url, {
+      amount: totalPrice(items), //Price is in cents
     }).then(
-         (response) => {
-            exact = ExactJS(response.data.token)
-            const components = exact.components({orderId: response.data.orderId});
-            components.addCard('cardElement', {
-                label: {position: "above"},
-                style: {
-                    default: {
-                        padding: '2px',
-                        border: "1px solid #ccc",
-                        fontSize: "14px",
-                        backgroundColor: "#b6bdcb"
-                      },
-                }});
+      (response) => {
+        exact = ExactJS(response.data.token)
+        const components = exact.components({ orderId: response.data.orderId });
+        components.addCard('cardElement', {
+          label: { position: "above" },
+          style: {
+            default: {
+              padding: '2px',
+              border: "1px solid #ccc",
+              fontSize: "14px",
+              backgroundColor: "#b6bdcb"
+            },
+          }
+        });
+
+        components.addComponent('addressElement', 'address', {
+          billingAddress: {
+            type: "minimal",
+          },
+          label: { position: "above" },
+          style: {
+            default: {
+              padding: '2px',
+              border: "1px solid #ccc",
+              fontSize: "14px",
+              backgroundColor: "#b6bdcb"
+            },
+          }
+        });
 
 
-            exact.on("payment-complete", (payload : unknown) => {
-                const tokenPayload = payload as ExactJSTokenPayload
-                (document.getElementById('token')! as HTMLInputElement).value  = tokenPayload.token;
-                (document.getElementById('card_brand')! as HTMLInputElement).value  = tokenPayload.card_brand;
-                (document.getElementById('expiry_month')! as HTMLInputElement).value  = tokenPayload.expiry_month;
-                (document.getElementById('expiry_year')! as HTMLInputElement).value  = tokenPayload.expiry_year;
-                (document.getElementById('last4')! as HTMLInputElement).value  = tokenPayload.last4;
-                (document.getElementById('order_id')! as HTMLInputElement).value = response.data.orderId;
-                (document.getElementById('myForm') as HTMLFormElement).submit();
-            });
-            
-            exact.on("payment-failed", (payload) => {
-                console.debug(payload);
-            });
-            setTimeout(setOrderPosted, 1100);
-        })
+        exact.on("payment-complete", (payload: unknown) => {
+          const tokenPayload = payload as ExactJSTokenPayload
+          (document.getElementById('token')! as HTMLInputElement).value = tokenPayload.token;
+          (document.getElementById('card_brand')! as HTMLInputElement).value = tokenPayload.card_brand;
+          (document.getElementById('expiry_month')! as HTMLInputElement).value = tokenPayload.expiry_month;
+          (document.getElementById('expiry_year')! as HTMLInputElement).value = tokenPayload.expiry_year;
+          (document.getElementById('last4')! as HTMLInputElement).value = tokenPayload.last4;
+          (document.getElementById('order_id')! as HTMLInputElement).value = response.data.orderId;
+          (document.getElementById('myForm') as HTMLFormElement).submit();
+        });
+
+        exact.on("payment-failed", (payload) => {
+          console.debug(payload);
+        });
+        setTimeout(setOrderPosted, 1100);
+      })
+  }
+
+
+  const handleSubmit = (event: FormEvent<ExactPaymentForm>) => {
+    event.preventDefault()
+    exact.tokenize()
+    return false
+  }
+
+  //Prevent checkout with empty cart
+  const router = useRouter()
+  useEffect(() => {
+    if (!items) {
+      router.push('/')
     }
+  })
 
-    
-    const handleSubmit = (event : FormEvent<ExactPaymentForm>) => {
-        event.preventDefault()
-        exact.tokenize()
-        return false
-    }
-
-    //Prevent checkout with empty cart
-    const router = useRouter()
-    useEffect(() => {
-        if (!getTotalPrice()){
-            router.push('/')
-        }
-    })
-
-    return (
+  return (
     <>
-    <div className={styles.checkoutdisclaimer}>
+      <div className={styles.checkoutdisclaimer}>
         <h1>2-Pass Tokenized Payment</h1>
         <h2><a href="https://developer.exactpay.com/docs/test-cards/" target="_blank">TEST CARDS</a></h2>
-    </div>
-    
-    <main className={styles.main}>
-        <OrderTotal/>
-        <div id="loading">
-            <MutatingDots height="100" width="100" color="#d8908f" secondaryColor= '#d8908f' radius='12.5' ariaLabel="mutating-dots-loading"/>
+      </div>
 
-            <Script src="https://api.exactpaysandbox.com/js/v1/exact.js" strategy="afterInteractive" onReady={onExactJSReady}/>
+      <main className={styles.main}>
+        <OrderTotal />
+        <div id="loading">
+          <MutatingDots height="100" width="100" color="#d8908f" secondaryColor='#d8908f' radius='12.5' ariaLabel="mutating-dots-loading" />
+
+          <Script src={exactJsSource} strategy="afterInteractive" onReady={onExactJSReady} />
         </div>
 
         <div id="hideable" className={styles.hidden}>
-        <form id="myForm" action="api/receiveTokenAndPrint" method="post" onSubmit={handleSubmit}>
+          <form id="myForm" action="api/receiveTokenAndPrint" method="post" onSubmit={handleSubmit}>
             <div>
-                <label htmlFor="email">Email Address</label>
-                <input type="email" id="email" name="email" autoComplete="email" />
+              <label htmlFor="email">Email Address</label>
+              <input type="email" id="email" name="email" autoComplete="email" />
             </div>
 
-            <div id="cardElement" >
-
-            </div>
-
-            <div>
-                <label htmlFor="address">Address</label>
-                <input type="text" id="address" name="address" autoComplete="street-address" />
-            </div>
-
-            <div>
-                <label htmlFor ="apartment">Apartment, suite, etc.</label>
-                <input type="text" id="apartment" name="apartment" />
-            </div>
-
-            <div>
-                <label htmlFor="city">City</label>
-                <input type="text" id="city" name="city" />
-            </div>
-
-            <div>
-                <label htmlFor="province">State</label>
-                <input type="text" id="province" name="province" />
-            </div>
-
-            <div>
-                <label htmlFor="postcode">Postal code</label>
-                <input type="text" id="postcode" name="postcode" autoComplete="postal-code" />
-            </div>
+            <div id="cardElement" ></div>
+            <div id="addressElement" ></div>
 
             <input type="hidden" name="token" id="token"></input>
             <input type="hidden" name="card_brand" id="card_brand"></input>
@@ -137,13 +125,12 @@ export default  function Checkout() {
             <input type="hidden" name="order_id" id="order_id"></input>
 
             <div>
-                <input type="submit" name="commit" value="Pay Now" data-disable-with="Pay Now" />
+              <input type="submit" name="commit" value="Pay Now" data-disable-with="Pay Now" />
             </div>
-        </form>
+          </form>
         </div>
-    </main>
+      </main>
     </>
-    )
+  )
 }
 
-  

--- a/tokenize-from-browser/pages/index.tsx
+++ b/tokenize-from-browser/pages/index.tsx
@@ -3,13 +3,24 @@ import Head from 'next/head'
 import styles from '../styles/Home.module.css'
 
 import Cart from '../components/Cart'
-import  StoreItem  from '../components/StoreItem'
+import StoreItem from '../components/StoreItem'
 import CheckoutButton from '../components/CheckoutButton'
 import ClearCartButton from '../components/ClearCartButton'
 import OrderTotal from '../components/OrderTotal'
 
+import https from 'https'
+import axios from 'axios'
 
 export default function Home() {
+
+  if (process.env.NODE_ENV === 'development') {
+    const httpsAgent = new https.Agent({
+      rejectUnauthorized: false,
+    })
+    axios.defaults.httpsAgent = httpsAgent
+    // eslint-disable-next-line no-console
+    console.log(process.env.NODE_ENV, `RejectUnauthorized is disabled.`)
+  }
 
   return (
     <div className={styles.container}>
@@ -19,52 +30,42 @@ export default function Home() {
         <link rel="icon" href="/favicon.png" />
       </Head>
       <div className={styles.grid}>
-      <main className={styles.main}>
-        <h1 className={styles.title}>
-          Welcome to <a href="https://developer.exactpay.com">Exact Payments</a> Flower Shop
-        </h1>
+        <main className={styles.main}>
+          <h2 className={styles.title}>
+            Welcome to the <a href="https://developer.exactpay.com">Exact Payments</a> Plant Shop
+          </h2>
 
-        <p className={styles.description}>
-          Get started by clicking on a Plant to add to your <code className={styles.code}>Cart</code>
-          <br/>
-          <br/>
-          We are having a sale today- all plants are $10.00 USD!
-        </p>
+          <p className={styles.description}>
+            Get started by clicking on a Plant to add to your <code className={styles.code}>Cart</code>
+          </p>
 
+          <div className={styles.itemgrid}>
+            <StoreItem itemnum={"01"} price={100} />
+            <StoreItem itemnum={"02"} price={200} />
+            <StoreItem itemnum={"03"} price={300} />
+            <StoreItem itemnum={"04"} price={400} />
+            <StoreItem itemnum={"05"} price={500} />
+            <StoreItem itemnum={"06"} price={600} />
+          </div>
+        </main>
 
-        <div className={styles.itemgrid}>
-          <StoreItem itemnum={"01"}/>
-          <StoreItem itemnum={"02"}/>
-          <StoreItem itemnum={"03"}/>
-          <StoreItem itemnum={"04"}/>
-          <StoreItem itemnum={"05"}/>
-          <StoreItem itemnum={"06"}/>
-        </div>
-      </main>
-      <main className={styles.cart}>
-        <h1 >Cart</h1> 
-        <OrderTotal/>
-        <div className={styles.cartgrid}>
-          <Cart/>
-        </div>
-        <div className={styles.checkout}>
-          <CheckoutButton />
-          <ClearCartButton/>
-        </div>
-        
-
-
-      </main>
-
+        <main className={styles.cart}>
+          <h1 >Cart</h1>
+          <OrderTotal />
+          <div className={styles.cartgrid}>
+            <Cart />
+          </div>
+          <div className={styles.checkout}>
+            <CheckoutButton />
+            <ClearCartButton />
+          </div>
+        </main>
       </div>
-      
 
       <footer className={styles.footer}>
-          Exact Payments 2022
+        Exact Payments &copy; 2023
       </footer>
     </div>
-    
-    
   )
 }
 

--- a/tokenize-from-browser/pages/paid.tsx
+++ b/tokenize-from-browser/pages/paid.tsx
@@ -7,47 +7,52 @@ import { PaymentInfo } from '../types';
 import { MutatingDots } from 'react-loader-spinner';
 
 const fetchPaymentInfo = async () => {
-    const response = await axios.get(process.env.NEXT_PUBLIC_BASE_URL + '/api/demoPayWithToken');
-    return response.data;
+  const response = await axios.get(process.env.NEXT_PUBLIC_BASE_URL + '/api/demoPayWithToken');
+  return response.data;
 };
 
-export default function Paid () {
-    const [paymentInfo, setPaymentInfo] = useState({} as PaymentInfo);
-    const [loading, setLoading] = useState(true);
+export default function Paid() {
+  const [paymentInfo, setPaymentInfo] = useState({} as PaymentInfo);
+  const [loading, setLoading] = useState(true);
 
 
-    useEffect(() => {
-        fetchPaymentInfo().then(response => {
-            setPaymentInfo(response);
-            setLoading(false);
-        });
-    }, [setPaymentInfo, setLoading]
-    );
+  useEffect(() => {
+    fetchPaymentInfo().then(response => {
+      setPaymentInfo(response);
+      setLoading(false);
+    });
+  }, [setPaymentInfo, setLoading]
+  );
 
-    if (loading) return (
+  if (loading) return (
     <main className={styles.main}>
-    <MutatingDots height="100" width="100" color="#4fa94d" 
-    secondaryColor= '#4fa94d' radius='12.5' ariaLabel="mutating-dots-loading"/>
+      <MutatingDots height="100" width="100" color="#4fa94d"
+        secondaryColor='#4fa94d' radius='12.5' ariaLabel="mutating-dots-loading" />
     </main>
-    )
+  )
     ;
-    else return (<>
-        <main className={styles.main}>
-            <h1>
-            Thanks for shopping at the Exact Plant Shop <br></br>
-            </h1>
-            <h3>
-            The details of your payment have been sent to the server!
-            </h3>
-            <p>
-            Displaying payment details for demonstration
-            </p>
-            <div>
-            <PaymentInfoBox paymentInfo={paymentInfo} />
-            </div>
-            <h1>
-            <Link href='/'>Return to our homepage</Link>
-            </h1>
-        </main>
-    </>)
+  else return (<>
+    <main className={styles.main}>
+      <h1>
+        Thanks for shopping at the Exact Payments Plant Shop <br></br>
+      </h1>
+      <h3>
+        The details of your payment have been sent to the server!
+      </h3>
+      <p>
+        Displaying payment details from
+        <a href="https://developer.exactpay.com/api#/paths/account-accountId--payments--paymentId/get">
+          &nbsp;API&nbsp;
+        </a>
+        for demonstration
+      </p>
+      <div>
+
+        <PaymentInfoBox paymentInfo={paymentInfo} />
+      </div>
+      <h1>
+        <Link href='/'>Return to our homepage</Link>
+      </h1>
+    </main>
+  </>)
 }

--- a/tokenize-from-browser/pages/token.tsx
+++ b/tokenize-from-browser/pages/token.tsx
@@ -2,78 +2,77 @@ import Link from 'next/link'
 import axios from 'axios';
 import { useEffect, useState } from 'react';
 import styles from 'styles/Home.module.css'
-import PaymentInfoBox from '../components/PaymentInfoBox'
 import { TokenInfo } from '../types';
 import { MutatingDots } from 'react-loader-spinner';
 
 const fetchPaymentInfo = async () => {
-    const response = await axios.get(process.env.NEXT_PUBLIC_BASE_URL + '/api/demoPrintToken');
-    return response.data;
+  const response = await axios.get(process.env.NEXT_PUBLIC_BASE_URL + '/api/demoPrintToken');
+  return response.data;
 };
 
-export default function Paid () {
-    const [tokenInfo, setTokenInfo] = useState({} as TokenInfo);
-    const [loading, setLoading] = useState(true);
+export default function Paid() {
+  const [tokenInfo, setTokenInfo] = useState({} as TokenInfo);
+  const [loading, setLoading] = useState(true);
 
 
-    useEffect(() => {
-        fetchPaymentInfo().then(response => {
-            setTokenInfo(response);
-            setLoading(false);
-        });
-    }, [setTokenInfo, setLoading]
-    );
+  useEffect(() => {
+    fetchPaymentInfo().then(response => {
+      setTokenInfo(response);
+      setLoading(false);
+    });
+  }, [setTokenInfo, setLoading]
+  );
 
-    if (loading) return (
+  if (loading) return (
     <main className={styles.main}>
-    <MutatingDots height="100" width="100" color="#4fa94d" 
-    secondaryColor= '#4fa94d' radius='12.5' ariaLabel="mutating-dots-loading"/>
+      <MutatingDots height="100" width="100" color="#4fa94d"
+        secondaryColor='#4fa94d' radius='12.5' ariaLabel="mutating-dots-loading" />
     </main>
-    )
+  )
     ;
-    else return (<>
-        <main className={styles.main}>
-            <h1>
-            Thanks for shopping at the Exact Plant Shop <br></br>
-            </h1>
-            <h3>
-            Your payment was tokenized.
-            </h3>
-            <h3>
-                <a href="https://developer.exactpay.com/api/#/operations/post-account-accountId-orders-orderId-pay"
-                target="_blank">
-                Pay for Order with Token
-                </a>
-            </h3>
-            <p>
-            Displaying info for demonstration.
-            </p>
-            <div>
-            orderId: {tokenInfo.orderId}
-            </div>
-            <div>
-            token: {tokenInfo.token}
-            </div>
-            <div>
-            cardBrand: {tokenInfo.cardBrand}
-            </div>
-            <div>
-            expiryMonth: {tokenInfo.expiryMonth}
-            </div>
-            <div>
-            expiryYear: {tokenInfo.expiryYear}
-            </div>
-            <div>
-            last4: {tokenInfo.last4}
-            </div>
-            <div>
-            accountId: {tokenInfo.accountId}
-            </div>
-            
-            
-            <h1>
-            <Link href='/'>Return to our homepage</Link>
-            </h1>
-        </main>
-    </>)
+  else return (<>
+    <main className={styles.main}>
+      <h1>
+        Thanks for shopping at the Exact Plant Shop <br></br>
+      </h1>
+      <h3>
+        Your payment was tokenized.
+      </h3>
+      <h3>
+        <a href="https://developer.exactpay.com/api/#/operations/post-account-accountId-orders-orderId-pay"
+          target="_blank">
+          Pay for Order with Token
+        </a>
+      </h3>
+      <p>
+        Displaying info for demonstration.
+      </p>
+      <div>
+        orderId: {tokenInfo.orderId}
+      </div>
+      <div>
+        token: {tokenInfo.token}
+      </div>
+      <div>
+        cardBrand: {tokenInfo.cardBrand}
+      </div>
+      <div>
+        expiryMonth: {tokenInfo.expiryMonth}
+      </div>
+      <div>
+        expiryYear: {tokenInfo.expiryYear}
+      </div>
+      <div>
+        last4: {tokenInfo.last4}
+      </div>
+      <div>
+        accountId: {tokenInfo.accountId}
+      </div>
+
+
+      <h1>
+        <Link href='/'>Return to our homepage</Link>
+      </h1>
+    </main>
+  </>)
 }

--- a/tokenize-from-browser/types.ts
+++ b/tokenize-from-browser/types.ts
@@ -1,98 +1,101 @@
 declare global {
-    let ExactJS: (key : string, locale? : {locale : string}) => Exact;
-  }
-export type Exact = {
-    components : (order : {orderId : string}) => Component,
-    payOrder : () => Promise<string>,
-    on : (paymentState : "payment-complete" | "payment-failed", functionCall: (payload :ExactJSPaymentPayload | ExactJSTokenPayload) => void) => void,
-    tokenize : () => void
+  let ExactJS: (key: string, locale?: { locale: string }) => Exact;
 }
-export type Component =  {
-    addCard : (divName : string, payload? : {"style"? : Styling, "wallets"? :boolean, label?: Label }) => void;
-    addComponent : (divName : string, divId: string, payload? : {"style"? : Styling, "wallets"? :boolean, label?: Label }) => void;
+export type Exact = {
+  components: (order: { orderId: string }) => Component,
+  payOrder: () => Promise<string>,
+  on: (paymentState: "payment-complete" | "payment-failed", functionCall: (payload: ExactJSPaymentPayload | ExactJSTokenPayload) => void) => void,
+  tokenize: () => void
+}
+export type Component = {
+  addCard: (divName: string, payload?: { "style"?: Styling, "wallets"?: boolean, label?: Label }) => void;
+  addComponent: (divName: string, divId: string, payload?: { "billingAddress"?: BillingAddress, "style"?: Styling, "wallets"?: boolean, label?: Label }) => void;
 }
 
 export type ExactJSPaymentPayload = {
-    paymentId : string 
+  paymentId: string
 }
 export type ExactJSTokenPayload = {
-    token : string
-    card_brand : string
-    last4 : string
-    expiry_month: string
-    expiry_year: string
+  token: string
+  card_brand: string
+  last4: string
+  expiry_month: string
+  expiry_year: string
 }
 
 
+export type BillingAddress = {
+  type: string
+}
 
 export type Label = {
-    //Labels
-    position: "above" | "inside" | "none"
+  //Labels
+  position: "above" | "inside" | "none"
 }
 export type Styling = {
-    
-    default: Style,
-    error?: Style,
-    
+
+  default: Style,
+  error?: Style,
+
 }
 export type Style = {
-    //General Styling
-    padding? : string,
-    color? : string,
-    fontFamily? : string,
-    fontSize? : string,
-    fontWeight? : string,
-    textAlign? : string,
-    textTransform? : string,
-    textShadow? : string,
-    fontStyle? :string,
+  //General Styling
+  padding?: string,
+  color?: string,
+  fontFamily?: string,
+  fontSize?: string,
+  fontWeight?: string,
+  textAlign?: string,
+  textTransform?: string,
+  textShadow?: string,
+  fontStyle?: string,
 
-    //Input Styling
-    backgroundColor? : string,
-    border? : string,
-    borderRadius? : string,
-    borderWidth? : string,
-    borderColor? : string,
+  //Input Styling
+  backgroundColor?: string,
+  border?: string,
+  borderRadius?: string,
+  borderWidth?: string,
+  borderColor?: string,
 
-    
+
 }
 
-export interface ExactPaymentForm extends HTMLFormElement{
-    closest : (form_name: string) => {
-        submit : () => void
-    }
+export interface ExactPaymentForm extends HTMLFormElement {
+  closest: (form_name: string) => {
+    submit: () => void
+  }
 }
 
 export type Data = {
-    token: string,
-    orderId : string
-  }
+  token: string,
+  orderId: string
+}
 
 export type PaymentInfo = {
 
-    id: string,
-    paymentId: string,
-    terminalId: string,
-    merchantId: string,
-    accountId: string,
-    type: string,
-    status: string,
-    approved: boolean,
-    captured: boolean,
-    voided: boolean,
-    refunded: boolean,
-    settled: boolean,
-    amount: number,
-    sentToBank: boolean,
-    createdAt: string
+  id: string,
+  paymentId: string,
+  terminalId: string,
+  merchantId: string,
+  accountId: string,
+  type: string,
+  status: string,
+  approved: boolean,
+  captured: boolean,
+  voided: boolean,
+  refunded: boolean,
+  settled: boolean,
+  amount: number,
+  sentToBank: boolean,
+  createdAt: string
 }
 
 export type TokenInfo = {
-    token : string,
-    orderId : string,
-    accountId : string,
-    cardBrand : string,
-    expiryMonth : string,
-    expiryYear : string,
-    last4 : string
+  token: string,
+  orderId: string,
+  accountId: string,
+  cardBrand: string,
+  expiryMonth: string,
+  expiryYear: string,
+  last4: string
 }

--- a/tokenize-from-browser/types.ts
+++ b/tokenize-from-browser/types.ts
@@ -5,7 +5,8 @@ export type Exact = {
   components: (order: { orderId: string }) => Component,
   payOrder: () => Promise<string>,
   on: (paymentState: "payment-complete" | "payment-failed", functionCall: (payload: ExactJSPaymentPayload | ExactJSTokenPayload) => void) => void,
-  tokenize: () => void
+  tokenize: () => void,
+  reset: () => void,
 }
 export type Component = {
   addCard: (divName: string, payload?: { "style"?: Styling, "wallets"?: boolean, label?: Label }) => void;
@@ -22,7 +23,6 @@ export type ExactJSTokenPayload = {
   expiry_month: string
   expiry_year: string
 }
-
 
 export type BillingAddress = {
   type: string
@@ -56,8 +56,6 @@ export type Style = {
   borderRadius?: string,
   borderWidth?: string,
   borderColor?: string,
-
-
 }
 
 export interface ExactPaymentForm extends HTMLFormElement {
@@ -66,13 +64,13 @@ export interface ExactPaymentForm extends HTMLFormElement {
   }
 }
 
-export type Data = {
+export type Order = {
   token: string,
-  orderId: string
+  orderId: string,
+  totalAmount: number
 }
 
 export type PaymentInfo = {
-
   id: string,
   paymentId: string,
   terminalId: string,

--- a/tokenize-from-browser/util/useCartState.tsx
+++ b/tokenize-from-browser/util/useCartState.tsx
@@ -1,12 +1,18 @@
 import create from 'zustand';
 
+export type StoreItemProps = {
+  itemnum: string;
+  price: number;
+};
+
 interface ItemState {
-  items: string[];
-  addItem: (item: string) => void;
+  items: StoreItemProps[];
+  addItem: (item: StoreItemProps) => void;
   removeAllItems: () => void;
 }
+
 export const useCartState = create<ItemState>((set) => ({
   items: [],
-  addItem: (item: string) => set((state) => ({ items: [...state.items, item] })),
+  addItem: (item: StoreItemProps) => set((state) => ({ items: [...state.items, item] })),
   removeAllItems: () => set({ items: [] }),
 }));

--- a/tokenize-from-browser/util/useCartState.tsx
+++ b/tokenize-from-browser/util/useCartState.tsx
@@ -1,4 +1,5 @@
 import create from 'zustand';
+import { Order } from '../types';
 
 export type StoreItemProps = {
   itemnum: string;
@@ -7,12 +8,16 @@ export type StoreItemProps = {
 
 interface ItemState {
   items: StoreItemProps[];
+  order: Order | null;
   addItem: (item: StoreItemProps) => void;
   removeAllItems: () => void;
+  setOrder: (order: Order) => void;
 }
 
 export const useCartState = create<ItemState>((set) => ({
   items: [],
+  order: null,
   addItem: (item: StoreItemProps) => set((state) => ({ items: [...state.items, item] })),
   removeAllItems: () => set({ items: [] }),
+  setOrder: (order: Order) => set({ order: order }),
 }));


### PR DESCRIPTION
This PR
- reworks the flow to create an Order before we render the checkout page
- will update the order if the customer goes back to the Card and changes the contents
- adds a `cleanupExactJS` function which calls `reset()` on ExactJS, causing it to remove its frames/listeners from the page.

Note: the `reset()` function is only present in the matching P1 PR: https://github.com/exact-payments/p1/pull/469 