### PR TITLE
PAY-458 Enabled wallets for standard payout flow

### DIFF
--- a/pay-from-browser/README.md
+++ b/pay-from-browser/README.md
@@ -82,7 +82,7 @@ We are loading ExactJS here via a `<Script>` tag, and calling `onExactJSReady()`
 
 We display a loading icon, to dissapear after ExactJS loads.
 
-We display a form with sections for email address, street address, apartment, city, province, postal code. The form is initially hidden.
+We display a form with sections for street address, apartment, city, province, postal code. The form is initially hidden.
 
 The form calls `handleSubmit()` when submitted and `api/receivePaymentId` when the payment is completed.
 

--- a/pay-from-browser/package.json
+++ b/pay-from-browser/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 4000",
     "build": "next build",
-    "start": "next start",
+    "start": "next start -p 4000",
     "lint": "next lint"
   },
   "dependencies": {

--- a/pay-from-browser/package.json
+++ b/pay-from-browser/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev -p 4000",
     "build": "next build",
-    "start": "next start -p 4000",
+    "start": "next start",
     "lint": "next lint"
   },
   "dependencies": {

--- a/pay-from-browser/pages/checkout.tsx
+++ b/pay-from-browser/pages/checkout.tsx
@@ -20,6 +20,7 @@ export default function Checkout() {
     const components = exact.components({ orderId: store.order?.orderId as string })
 
     components.addCard('cardElement', {
+      wallets: true,
       label: { position: "above" },
       style: {
         default: {
@@ -85,16 +86,10 @@ export default function Checkout() {
         <OrderTotal />
         <div id="paymentForm" className={styles.paymentForm}>
           <form id="myForm" action="api/receivePaymentId" method="post" onSubmit={handleSubmit}>
-            <div>
-              <label htmlFor="email">Email Address</label>
-              <input type="email" id="email" name="email" autoComplete="email" />
-            </div>
 
-            <div id="cardElement" className={styles.paymentElement}>
-            </div>
+            <div id="cardElement" className={styles.paymentElement}></div>
 
-            <div id="addressDiv" className={styles.paymentElement}>
-            </div>
+            <div id="addressDiv" className={styles.paymentElement}></div>
 
             <input type="hidden" name="payment_id" id="payment_id"></input>
 


### PR DESCRIPTION
This PR will
- enable wallets for the default `pay-from-browser` flow
- remove the email address field from that layout to make it cleaner